### PR TITLE
CO-3266 Miscellaneous improvements for project creation form

### DIFF
--- a/cms_form/models/widgets/widget_date.py
+++ b/cms_form/models/widgets/widget_date.py
@@ -16,10 +16,19 @@ class DateWidget(models.AbstractModel):
 
     def widget_init(self, form, fname, field, **kw):
         widget = super().widget_init(form, fname, field, **kw)
-        if kw.get('format', widget.w_date_format):
-            widget.w_data['dp'] = {
-                'format': kw.get('format', widget.w_date_format)
-            }
+        widget.w_data["dp"] = {}
+        if kw.get("format", widget.w_date_format):
+            widget.w_data["dp"].update({
+                "format": kw.get("format", widget.w_date_format)
+            })
+        if kw.get("min_date"):
+            widget.w_data["dp"].update({
+                "min_date": kw.get("min_date")
+            })
+        if kw.get("max_date"):
+            widget.w_data["dp"].update({
+                "max_date": kw.get("max_date")
+            })
         widget.w_placeholder = kw.get('placeholder', widget.w_placeholder)
         return widget
 

--- a/cms_form/static/src/js/date_widget.js
+++ b/cms_form/static/src/js/date_widget.js
@@ -72,7 +72,21 @@ odoo.define('cms_form.date_widget', function (require) {
                     }
                 }
                 self.$realField.val(real_val);
-        }}));
+            },
+            disableDates:  function (date) {
+                // Reception of the dates in their isoformat form (string) or as undefined
+                const minDateStr = this.params.dp.min_date;
+                const maxDateStr = this.params.dp.max_date;
+                // Convertion to dates
+                const minDate = new Date(minDateStr).setHours(0,0,0,0);
+                const maxDate = new Date(maxDateStr).setHours(0,0,0,0);
+                // Verify that it is in valid range
+                return minDateStr === undefined && maxDateStr === undefined ||
+                        minDateStr === undefined && date <= maxDate ||
+                        minDate <= date && maxDateStr === undefined ||
+                        minDate <= date && date <= maxDate;
+            }
+        }));
       this._init_date();
     },
     _init_date: function () {

--- a/cms_form/templates/form.xml
+++ b/cms_form/templates/form.xml
@@ -302,7 +302,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
         <button type="submit" class="btn btn-primary pull-right">Submit</button>
       </t>
       <t t-if="form.wiz_prev_step()">
-        <button type="submit" name="wiz_submit" value="prev" class="btn btn-primary btn-prev pull-left">Prev</button>
+        <button type="submit" name="wiz_submit" value="prev" class="btn btn-primary btn-prev pull-left" formnovalidate="True">Prev</button>
       </t>
      </div>
   </xpath>


### PR DESCRIPTION
This PR adds the possibility for a _date_widget_ to use a minimum and maximum date to determine the range of possible values. The widget verifies that a selected date is actually greater or equal than the minimum and smaller or equal than the maximum. Also, it adds the possibility to go back (using the _previous_ button) even if the actual page of the form is not filled.

There is a parallel PR on [compassion-switzerland](https://github.com/CompassionCH/compassion-switzerland) (https://github.com/CompassionCH/compassion-switzerland/pull/1122), which uses these improvements for a concrete form (to create a crowdfunding project).